### PR TITLE
Implement incremental sprint planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 dist/
 build/
 .dist/
+.tsbuildinfo
 
 # Generated files
 generated/

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -338,7 +338,7 @@ const swaggerOptions: swaggerJsDoc.Options = {
             id: { type: 'string' },
             title: { type: 'string' },
             description: { type: 'string' },
-            lengthDays: { type: 'integer', enum: [3, 7, 14] },
+            lengthDays: { type: 'integer', enum: [1, 3, 7, 14] },
             totalEstimatedHours: { type: 'number' },
             difficulty: { type: 'string', enum: ['beginner', 'intermediate', 'advanced'] },
             projects: {
@@ -482,7 +482,38 @@ const swaggerOptions: swaggerJsDoc.Options = {
               },
               nullable: true
             },
-            adaptationNotes: { type: 'string' }
+            adaptationNotes: { type: 'string' },
+            metadata: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                plannerVersion: { type: 'string' },
+                requestedAt: { type: 'string' },
+                provider: { type: 'string', enum: ['remote', 'fallback'] },
+                objectiveId: { type: 'string' },
+                learnerProfileId: { type: 'string', nullable: true },
+                preferLength: { type: 'integer', nullable: true },
+                mode: { type: 'string', enum: ['skeleton', 'expansion'] },
+                incremental: { type: 'boolean' },
+                expansionGoal: {
+                  type: 'object',
+                  nullable: true,
+                  properties: {
+                    targetLengthDays: { type: 'integer', nullable: true },
+                    additionalMicroTasks: { type: 'integer', nullable: true }
+                  }
+                }
+              },
+              additionalProperties: true
+            }
+          }
+        },
+        SprintExpansionRequest: {
+          type: 'object',
+          properties: {
+            targetLengthDays: { type: 'integer', enum: [1, 3, 7, 14] },
+            additionalDays: { type: 'integer', minimum: 1, maximum: 14 },
+            additionalMicroTasks: { type: 'integer', minimum: 1, maximum: 12 }
           }
         },
         SprintPlanResponse: {

--- a/src/controllers/objectiveController.ts
+++ b/src/controllers/objectiveController.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { createObjectiveSchema, generateSprintSchema } from '../validation/objectiveSchemas.js';
+import { createObjectiveSchema, expandSprintSchema, generateSprintSchema } from '../validation/objectiveSchemas.js';
 import { submitSprintEvidenceSchema, reviewSprintSchema } from '../validation/reviewerSchemas.js';
 import { objectiveService } from '../services/objectiveService.js';
 import { AuthRequest } from '../middlewares/authMiddleware';
@@ -118,6 +118,49 @@ export class ObjectiveController {
     sendTranslatedResponse(res, 'objectives.sprint.generated', {
       statusCode: 201,
       data: sprint
+    });
+  }
+
+  async expandSprint(req: AuthRequest, res: Response): Promise<void> {
+    if (!req.userId) {
+      res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
+        timestamp: new Date().toISOString()
+      });
+      return;
+    }
+
+    const validation = expandSprintSchema.safeParse({
+      ...req.body,
+      objectiveId: req.params.objectiveId,
+      sprintId: req.params.sprintId
+    });
+
+    if (!validation.success) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'INVALID_SPRINT_EXPANSION_PAYLOAD',
+          message: validation.error.message
+        },
+        timestamp: new Date().toISOString()
+      });
+      return;
+    }
+
+    const result = await objectiveService.expandSprint({
+      userId: req.userId,
+      objectiveId: validation.data.objectiveId,
+      sprintId: validation.data.sprintId,
+      targetLengthDays: validation.data.targetLengthDays,
+      additionalDays: validation.data.additionalDays,
+      additionalMicroTasks: validation.data.additionalMicroTasks
+    });
+
+    sendTranslatedResponse(res, 'objectives.sprint.expanded', {
+      statusCode: 200,
+      data: result
     });
   }
 

--- a/src/locales/en/objectives.json
+++ b/src/locales/en/objectives.json
@@ -15,6 +15,7 @@
   },
   "sprint": {
     "generated": "Sprint generated successfully.",
+    "expanded": "Sprint expanded successfully.",
     "retrieved": "Sprint retrieved successfully.",
     "evidenceSaved": "Sprint evidence submitted successfully.",
     "reviewCompleted": "Sprint reviewed successfully.",

--- a/src/locales/fr/objectives.json
+++ b/src/locales/fr/objectives.json
@@ -15,6 +15,7 @@
   },
   "sprint": {
     "generated": "Sprint généré avec succès.",
+    "expanded": "Sprint étendu avec succès.",
     "retrieved": "Sprint récupéré avec succès.",
     "evidenceSaved": "Preuves du sprint enregistrées avec succès.",
     "reviewCompleted": "Sprint évalué avec succès.",

--- a/src/repositories/sprintRepository.ts
+++ b/src/repositories/sprintRepository.ts
@@ -20,6 +20,7 @@ export interface SprintCreateInput {
 }
 
 export interface SprintUpdateInput {
+  plannerInput?: Prisma.JsonValue;
   plannerOutput?: Prisma.JsonValue;
   status?: SprintStatus;
   startedAt?: Date | null;

--- a/src/routes/objectiveRoutes.ts
+++ b/src/routes/objectiveRoutes.ts
@@ -122,8 +122,8 @@ router.get('/:objectiveId', authMiddleware, objectiveController.getObjective.bin
  * @swagger
  * /api/objectives/{objectiveId}/sprints/generate:
  *   post:
- *     summary: Generate a new sprint for an objective
- *     description: Uses the learner profile context to create the next sprint plan for a given objective.
+ *     summary: Generate the initial skeleton sprint for an objective
+ *     description: Creates a one-day, three micro-task sprint skeleton so learners can start immediately. Additional scope can be added later via the expansion endpoint.
  *     tags: [Objectives]
  *     security:
  *       - bearerAuth: []
@@ -146,7 +146,8 @@ router.get('/:objectiveId', authMiddleware, objectiveController.getObjective.bin
  *                 format: uuid
  *               preferLength:
  *                 type: integer
- *                 enum: [3, 7, 14]
+ *                 enum: [1, 3, 7, 14]
+ *                 description: Desired eventual sprint length (used as a target for future expansions). The initial skeleton is always 1 day.
  *     responses:
  *       201:
  *         description: Sprint generated successfully
@@ -170,6 +171,62 @@ router.get('/:objectiveId', authMiddleware, objectiveController.getObjective.bin
  *         description: Unauthorized
  */
 router.post('/:objectiveId/sprints/generate', authMiddleware, objectiveController.generateSprint.bind(objectiveController));
+
+/**
+ * @swagger
+ * /api/objectives/{objectiveId}/sprints/{sprintId}/expand:
+ *   post:
+ *     summary: Expand an existing sprint incrementally
+ *     description: Extends the current sprint plan by adding more days or micro-tasks while preserving previously generated work.
+ *     tags: [Objectives]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: objectiveId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: sprintId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/SprintExpansionRequest'
+ *     responses:
+ *       200:
+ *         description: Sprint expanded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *                   description: Localized success message using `objectives.sprint.expanded`
+ *                 data:
+ *                   $ref: '#/components/schemas/SprintPlanResponse'
+ *                 timestamp:
+ *                   type: string
+ *       400:
+ *         description: Invalid payload
+ *       401:
+ *         description: Unauthorized
+ */
+router.post(
+  '/:objectiveId/sprints/:sprintId/expand',
+  authMiddleware,
+  objectiveController.expandSprint.bind(objectiveController)
+);
 
 /**
  * @swagger

--- a/src/validation/objectiveSchemas.ts
+++ b/src/validation/objectiveSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 export const createObjectiveSchema = z.object({
   title: z.string().min(3),
   description: z.string().optional(),
@@ -11,6 +12,22 @@ export const createObjectiveSchema = z.object({
 export const generateSprintSchema = z.object({
   objectiveId: z.string().uuid(),
   learnerProfileId: z.string().uuid().optional(),
-  preferLength: z.number().int().optional(),
+  preferLength: z
+    .number()
+    .int()
+    .refine((value) => [1, 3, 7, 14].includes(value), 'preferLength must be 1, 3, 7, or 14 days')
+    .optional(),
   allowedResources: z.array(z.string()).optional()
+});
+
+export const expandSprintSchema = z.object({
+  objectiveId: z.string().uuid(),
+  sprintId: z.string().uuid(),
+  targetLengthDays: z
+    .number()
+    .int()
+    .refine((value) => [1, 3, 7, 14].includes(value), 'targetLengthDays must be 1, 3, 7, or 14 days')
+    .optional(),
+  additionalDays: z.number().int().min(1).max(14).optional(),
+  additionalMicroTasks: z.number().int().min(1).max(12).optional()
 });


### PR DESCRIPTION
## Summary
- add a skeleton sprint generation flow plus an expansion endpoint with validation, repository, and service updates
- adapt the planner client/service for incremental mode prompts, fallback merging, and richer metadata
- refresh API documentation, translations, and gitignore to cover the new incremental workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dabcf621388321a94df8f8ed49f691