### PR TITLE
Allow 1-day sprint length in planner client schema

### DIFF
--- a/src/services/plannerClient.ts
+++ b/src/services/plannerClient.ts
@@ -45,7 +45,7 @@ const SCHEMA_PROMPT = `JSON Schema (SprintPlan):
   "id": string,
   "title": string,
   "description": string,
-  "lengthDays": 3 | 7 | 14,
+  "lengthDays": 1 | 3 | 7 | 14,
   "totalEstimatedHours": number,
   "difficulty": "beginner" | "intermediate" | "advanced",
   "projects": [
@@ -104,7 +104,7 @@ interface SprintPlan {
   id: string;
   title: string;
   description: string;
-  lengthDays: 3 | 7 | 14;
+  lengthDays: 1 | 3 | 7 | 14;
   totalEstimatedHours: number;
   difficulty: "beginner" | "intermediate" | "advanced";
   projects: Array<{


### PR DESCRIPTION
## Summary
- allow the planner client schema prompt and SprintPlan interface to accept 1-day sprint lengths

## Testing
- npm run build *(fails: TS2393 duplicate function implementation in src/services/plannerService.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68dad3b199bc8321a6b53d8917e05800