### PR TITLE
Align planner sprint length options

### DIFF
--- a/src/services/plannerClient.ts
+++ b/src/services/plannerClient.ts
@@ -40,12 +40,16 @@ Rules:
 5. Output MUST be valid JSON and match the SprintPlan schema exactly.
 `;
 
+type SprintLength = 1 | 3 | 7 | 14;
+
+const LENGTH_DAYS_LITERAL = '1 | 3 | 7 | 14';
+
 const SCHEMA_PROMPT = `JSON Schema (SprintPlan):
 {
   "id": string,
   "title": string,
   "description": string,
-  "lengthDays": 1 | 3 | 7 | 14,
+  "lengthDays": ${LENGTH_DAYS_LITERAL},
   "totalEstimatedHours": number,
   "difficulty": "beginner" | "intermediate" | "advanced",
   "projects": [
@@ -104,7 +108,7 @@ interface SprintPlan {
   id: string;
   title: string;
   description: string;
-  lengthDays: 1 | 3 | 7 | 14;
+  lengthDays: SprintLength;
   totalEstimatedHours: number;
   difficulty: "beginner" | "intermediate" | "advanced";
   projects: Array<{


### PR DESCRIPTION
## Summary
- share a SprintLength union for planner client metadata
- update the schema prompt to list the 1 | 3 | 7 | 14 sprint length options consistently

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68dad8abcc3c8321b0ffcda0548c109d