### PR TITLE
Add timeout handling for planner client requests

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -72,6 +72,7 @@ export interface EnvironmentConfig {
   GROQ_API_KEY: string;
   GROQ_MODEL: string;
   PLANNER_VERSION: string;
+  PLANNER_REQUEST_TIMEOUT_MS: number;
   REVIEWER_PROVIDER: 'lmstudio' | 'groq';
   REVIEWER_LMSTUDIO_MODEL: string;
   REVIEWER_GROQ_MODEL: string;
@@ -159,6 +160,7 @@ export const config: EnvironmentConfig = {
   GROQ_API_KEY: process.env.GROQ_API_KEY || '',
   GROQ_MODEL: process.env.GROQ_MODEL || 'llama-3.1-70b',
   PLANNER_VERSION: process.env.PLANNER_VERSION || '2024-09-profile-context',
+  PLANNER_REQUEST_TIMEOUT_MS: parseInt(process.env.PLANNER_REQUEST_TIMEOUT_MS || '60000', 10),
   REVIEWER_PROVIDER:
     (process.env.REVIEWER_PROVIDER as 'lmstudio' | 'groq')
     || (process.env.PLANNER_PROVIDER as 'lmstudio' | 'groq')

--- a/src/services/plannerService.ts
+++ b/src/services/plannerService.ts
@@ -326,6 +326,7 @@ class PlannerService {
       model: resolvedTelemetry?.model,
       latencyMs: resolvedTelemetry?.latencyMs,
       promptHash: resolvedTelemetry?.promptHash,
+      timedOut: resolvedTelemetry?.timedOut ?? false,
       error: error instanceof Error ? error.message : error
     });
   }


### PR DESCRIPTION
## Summary
- add a configurable `PLANNER_REQUEST_TIMEOUT_MS` environment setting for planner calls
- apply abortable timeouts to planner client requests and surface timeout-specific telemetry details
- include timeout markers in planner service failure logging for clearer diagnostics

## Testing
- npm run lint *(fails: ESLint could not find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68dadc7e24008321b6c679583871bbaf