### PR TITLE
Trim schema prompts from planner guidance

### DIFF
--- a/src/services/reviewerClient.ts
+++ b/src/services/reviewerClient.ts
@@ -25,15 +25,6 @@ produce a numeric score (0..1), list achieved vs missing items, and propose **ne
 
 Return JSON strictly matching \`ReviewOutput\`.`;
 
-const SCHEMA_PROMPT = `JSON Schema (ReviewOutput):
-{
-  "score": number // 0..1,
-  "achieved": string[],
-  "missing": string[],
-  "nextRecommendations": string[],
-  "pass": boolean
-}`;
-
 type ProviderConfig =
   | {
       provider: 'groq';
@@ -139,9 +130,7 @@ function buildPrompt(payload: ReviewInput) {
     'Learner self-evaluation:',
     selfEvalJson,
     '',
-    SCHEMA_PROMPT,
-    '',
-    'Return valid JSON only.'
+    'Return ONLY valid JSON with no commentary. Output must match ReviewOutput { score (0..1), achieved[], missing[], nextRecommendations[], pass }. Schema checks are enforced by response_format when available.'
   ].join('\n');
 
   return {


### PR DESCRIPTION
## Summary
- stop appending the full SprintPlan schema in planner prompts and keep a concise reminder about the response_format enforcement
- remove the reviewer schema prompt helper and replace it with short guidance that still outlines the expected fields

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68daf526535c8321a95931cf7162d5f0