### PR TITLE
Adjust planner prompt schema reminder

### DIFF
--- a/src/services/plannerClient.ts
+++ b/src/services/plannerClient.ts
@@ -601,8 +601,6 @@ function buildPrompt(payload: PlannerRequestPayload) {
     }
   }
 
-  guidelines.push('Always return valid JSON matching the SprintPlan schema. Do not include commentary.');
-
   const promptSections: string[] = [
     `INCREMENTAL PLANNING MODE: ${mode.toUpperCase()}`,
     'GUIDELINES:',
@@ -627,7 +625,7 @@ function buildPrompt(payload: PlannerRequestPayload) {
 
   promptSections.push(`\nPREFERRED LENGTH: ${payload.preferLength ?? 'auto'}`);
   promptSections.push(
-    '\nReturn ONLY valid JSON with no commentary. Output must satisfy the SprintPlan schema (enforced by response_format when provided).'
+    '\nReturn ONLY valid JSON with no commentary. The SprintPlan schema is enforced via response_format.'
   );
 
   const userPrompt = promptSections.join('\n');


### PR DESCRIPTION
## Summary
- remove the redundant schema guideline from the planner prompt assembly
- keep a single reminder that response_format enforces the SprintPlan schema

## Testing
- PLANNER_PROVIDER=lmstudio LMSTUDIO_BASE_URL=http://localhost:1234 PLANNER_REQUEST_TIMEOUT_MS=5000 npx tsx tmp/testPlanner.ts *(fails: missing groq-sdk dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dafc48f158832184338cc200300fab