### PR TITLE
Increase LM Studio completion budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,7 @@ PADDLE_WEBHOOK_SECRET=""
 PLANNER_PROVIDER="lmstudio" # Options: lmstudio, groq
 LMSTUDIO_BASE_URL="http://localhost:1234"
 LMSTUDIO_MODEL="llama-3.1-8b-instruct"
+LMSTUDIO_MAX_TOKENS="4096" # Optional override for planner completions
 GROQ_BASE_URL="https://api.groq.com/openai/v1/chat/completions"
 GROQ_API_KEY="your-groq-api-key"
 GROQ_MODEL="llama-3.1-70b"

--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ GOOGLE_CALLBACK_URL="http://localhost:5050/api/auth/google/callback"
 GITHUB_CLIENT_ID="your-local-github-client-id"
 GITHUB_CLIENT_SECRET="your-local-github-client-secret"
 GITHUB_CALLBACK_URL="http://localhost:5050/api/auth/github/callback"
+
+# Planner / AI
+PLANNER_PROVIDER="lmstudio"
+LMSTUDIO_BASE_URL="http://localhost:1234"
+LMSTUDIO_MODEL="llama-3.1-8b-instruct"
+# Defaults to 4096 tokens if unset
+LMSTUDIO_MAX_TOKENS="4096"
 ```
 
 ### OAuth Provider Configuration

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -69,6 +69,7 @@ export interface EnvironmentConfig {
   LMSTUDIO_BASE_URL: string;
   LMSTUDIO_MODEL: string;
   LMSTUDIO_TIMEOUT_MS: number;
+  LMSTUDIO_MAX_TOKENS: number;
   GROQ_BASE_URL: string;
   GROQ_API_KEY: string;
   GROQ_MODEL: string;
@@ -168,6 +169,7 @@ export const config: EnvironmentConfig = {
       || '60000',
     10
   ),
+  LMSTUDIO_MAX_TOKENS: parseInt(process.env.LMSTUDIO_MAX_TOKENS || '4096', 10),
   REVIEWER_PROVIDER:
     (process.env.REVIEWER_PROVIDER as 'lmstudio' | 'groq')
     || (process.env.PLANNER_PROVIDER as 'lmstudio' | 'groq')

--- a/src/services/plannerClient.ts
+++ b/src/services/plannerClient.ts
@@ -822,10 +822,12 @@ function buildLmStudioRequest(
   responseSchemaName: string,
   maxTokens: number
 ) {
+  const resolvedMaxTokens = Math.max(maxTokens, config.LMSTUDIO_MAX_TOKENS);
+
   return {
     model,
     temperature: 0.2,
-    max_tokens: maxTokens,
+    max_tokens: resolvedMaxTokens,
     response_format: {
       type: 'json_schema',
       json_schema: {


### PR DESCRIPTION
## Summary
- add configuration for the LM Studio completion token budget with a higher default
- ensure planner requests honor the configured minimum completion budget
- document the new planner environment variable in the setup guides

## Testing
- npm run lint *(fails: ESLint 9 requires eslint.config.js in this repo)*

------
https://chatgpt.com/codex/tasks/task_b_68db0badc3148321bec03ea6c5e16e5e