### PR TITLE
Sanitize LM Studio plans missing evidence rubrics

### DIFF
--- a/src/services/__tests__/plannerService.sanitizeEvidenceRubric.test.ts
+++ b/src/services/__tests__/plannerService.sanitizeEvidenceRubric.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { plannerServiceTestables } from '../plannerService.js';
+
+test('ensureProjectEvidenceRubrics injects default rubric for missing project evidence', () => {
+  const rawPlan = {
+    id: 'spr_mock',
+    title: 'Mock plan',
+    description: 'A mock sprint plan for testing.',
+    lengthDays: 1,
+    totalEstimatedHours: 5,
+    difficulty: 'beginner',
+    projects: [
+      {
+        id: 'proj_missing_rubric',
+        title: 'Project missing rubric',
+        brief: 'This project omits the evidence rubric.',
+        requirements: ['Requirement 1'],
+        acceptanceCriteria: ['Acceptance 1'],
+        deliverables: [
+          { type: 'repository', title: 'Repo', artifactId: 'repo_1' }
+        ]
+      }
+    ],
+    microTasks: [
+      {
+        id: 'task-1',
+        projectId: 'proj_missing_rubric',
+        title: 'Task one',
+        type: 'project',
+        estimatedMinutes: 30,
+        instructions: 'Do the first thing.',
+        acceptanceTest: { type: 'checklist', spec: ['Check 1'] }
+      },
+      {
+        id: 'task-2',
+        projectId: 'proj_missing_rubric',
+        title: 'Task two',
+        type: 'project',
+        estimatedMinutes: 30,
+        instructions: 'Do the second thing.',
+        acceptanceTest: { type: 'checklist', spec: ['Check 2'] }
+      },
+      {
+        id: 'task-3',
+        projectId: 'proj_missing_rubric',
+        title: 'Task three',
+        type: 'project',
+        estimatedMinutes: 30,
+        instructions: 'Do the third thing.',
+        acceptanceTest: { type: 'checklist', spec: ['Check 3'] }
+      }
+    ],
+    adaptationNotes: 'No notes.'
+  };
+
+  const sanitized = plannerServiceTestables.ensureProjectEvidenceRubrics(rawPlan) as typeof rawPlan;
+
+  assert.notStrictEqual(sanitized, rawPlan, 'sanitizer should clone the incoming plan');
+  assert.strictEqual(
+    rawPlan.projects[0].evidenceRubric,
+    undefined,
+    'original payload should remain without a rubric'
+  );
+
+  const parsed = plannerServiceTestables.sprintPlanCoreSchema.safeParse(sanitized);
+  assert.ok(parsed.success, parsed.success ? undefined : JSON.stringify(parsed.error.issues, null, 2));
+
+  assert.deepStrictEqual(
+    sanitized.projects[0].evidenceRubric,
+    plannerServiceTestables.defaultEvidenceRubric,
+    'sanitized plan should include the default evidence rubric'
+  );
+
+  assert.strictEqual(
+    sanitized.projects[0].title,
+    rawPlan.projects[0].title,
+    'other project fields should be preserved'
+  );
+});

--- a/src/services/plannerClient.ts
+++ b/src/services/plannerClient.ts
@@ -40,12 +40,16 @@ Rules:
 5. Output MUST be valid JSON and match the SprintPlan schema exactly.
 `;
 
+type SprintLength = 1 | 3 | 7 | 14;
+
+const LENGTH_DAYS_LITERAL = '1 | 3 | 7 | 14';
+
 const SCHEMA_PROMPT = `JSON Schema (SprintPlan):
 {
   "id": string,
   "title": string,
   "description": string,
-  "lengthDays": 1 | 3 | 7 | 14,
+  "lengthDays": ${LENGTH_DAYS_LITERAL},
   "totalEstimatedHours": number,
   "difficulty": "beginner" | "intermediate" | "advanced",
   "projects": [
@@ -104,7 +108,7 @@ interface SprintPlan {
   id: string;
   title: string;
   description: string;
-  lengthDays: 1 | 3 | 7 | 14;
+  lengthDays: SprintLength;
   totalEstimatedHours: number;
   difficulty: "beginner" | "intermediate" | "advanced";
   projects: Array<{

--- a/src/services/plannerService.ts
+++ b/src/services/plannerService.ts
@@ -36,6 +36,11 @@ export interface GenerateSprintPlanInput {
   expansionGoal?: SprintPlanExpansionGoal | null;
 }
 
+type EvidenceRubric = {
+  dimensions: { name: string; weight: number; levels?: string[] }[];
+  passThreshold: number;
+};
+
 export interface SprintProjectPlan {
   id: string;
   title: string;
@@ -47,10 +52,7 @@ export interface SprintProjectPlan {
     title: string;
     artifactId: string;
   }[];
-  evidenceRubric: {
-    dimensions: { name: string; weight: number; levels?: string[] }[];
-    passThreshold: number;
-  };
+  evidenceRubric: EvidenceRubric;
   checkpoints?: { id: string; title: string; type: 'assessment' | 'quiz' | 'demo'; spec: string }[];
   support?: {
     concepts?: { id: string; title: string; summary: string }[];
@@ -138,6 +140,79 @@ const sprintPlanCoreSchema = z.object({
 });
 
 export type SprintPlanCore = z.infer<typeof sprintPlanCoreSchema>;
+
+const DEFAULT_EVIDENCE_RUBRIC: EvidenceRubric = Object.freeze({
+  dimensions: [
+    { name: 'Fonctionnalité', weight: 0.4 },
+    { name: 'Qualité du code', weight: 0.25 },
+    { name: 'Expérience utilisateur', weight: 0.2 },
+    { name: 'Documentation', weight: 0.15 }
+  ],
+  passThreshold: 0.7
+});
+
+const cloneDefaultEvidenceRubric = (): EvidenceRubric => ({
+  dimensions: DEFAULT_EVIDENCE_RUBRIC.dimensions.map(dimension => ({ ...dimension })),
+  passThreshold: DEFAULT_EVIDENCE_RUBRIC.passThreshold
+});
+
+const cloneValue = <T>(value: T): T => {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value));
+};
+
+const ensureProjectEvidenceRubrics = (rawPlan: unknown): unknown => {
+  if (!rawPlan || typeof rawPlan !== 'object') {
+    return rawPlan;
+  }
+
+  const clonedPlan = cloneValue(rawPlan) as Record<string, any>;
+
+  if (!Array.isArray(clonedPlan.projects)) {
+    return clonedPlan;
+  }
+
+  clonedPlan.projects = clonedPlan.projects.map(project => {
+    if (!project || typeof project !== 'object') {
+      return project;
+    }
+
+    const candidate = project as Record<string, any>;
+    const evidenceRubric = candidate.evidenceRubric as Record<string, any> | undefined;
+    const dimensions = evidenceRubric?.dimensions;
+    const passThreshold = evidenceRubric?.passThreshold;
+    const hasValidRubric =
+      Array.isArray(dimensions) &&
+      dimensions.length > 0 &&
+      dimensions.every(
+        (dimension: any) =>
+          dimension &&
+          typeof dimension.name === 'string' &&
+          typeof dimension.weight === 'number' &&
+          Number.isFinite(dimension.weight) &&
+          dimension.weight >= 0 &&
+          dimension.weight <= 1
+      ) &&
+      typeof passThreshold === 'number' &&
+      Number.isFinite(passThreshold) &&
+      passThreshold >= 0 &&
+      passThreshold <= 1;
+
+    if (hasValidRubric) {
+      return candidate;
+    }
+
+    return {
+      ...candidate,
+      evidenceRubric: cloneDefaultEvidenceRubric()
+    };
+  });
+
+  return clonedPlan;
+};
 
 export interface PlannerPlanMetadata {
   plannerVersion: string;
@@ -255,7 +330,8 @@ class PlannerService {
     input: GenerateSprintPlanInput,
     planId: string
   ): SprintPlanCore {
-    const parsed = sprintPlanCoreSchema.safeParse(rawPlan);
+    const sanitizedPlan = ensureProjectEvidenceRubrics(rawPlan);
+    const parsed = sprintPlanCoreSchema.safeParse(sanitizedPlan);
     if (!parsed.success) {
       throw new PlannerSchemaValidationError(parsed.error.issues);
     }
@@ -674,15 +750,7 @@ class PlannerService {
         { type: 'repository', title: 'Repository link', artifactId: `${projectId}_repo` },
         { type: 'deployment', title: 'Demo link', artifactId: `${projectId}_demo` }
       ],
-      evidenceRubric: {
-        dimensions: [
-          { name: 'Fonctionnalité', weight: 0.4 },
-          { name: 'Qualité du code', weight: 0.25 },
-          { name: 'Expérience utilisateur', weight: 0.2 },
-          { name: 'Documentation', weight: 0.15 }
-        ],
-        passThreshold: 0.7
-      },
+      evidenceRubric: cloneDefaultEvidenceRubric(),
       checkpoints: [
         {
           id: `${planId}_checkpoint_review`,
@@ -1092,5 +1160,11 @@ class PlannerService {
     return notes.join(' ');
   }
 }
+
+export const plannerServiceTestables = {
+  ensureProjectEvidenceRubrics,
+  sprintPlanCoreSchema,
+  defaultEvidenceRubric: DEFAULT_EVIDENCE_RUBRIC
+};
 
 export const plannerService = new PlannerService();


### PR DESCRIPTION
## Summary
- share a reusable default project evidence rubric in the planner service and reuse it for fallback plans
- sanitize remote planner responses to backfill missing or malformed evidence rubrics before schema validation
- add a regression test to ensure plans lacking evidence rubrics now parse successfully

## Testing
- npm run build *(fails: TypeScript reports pre-existing duplicate function implementations in plannerService.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68dad8abcc3c8321b0ffcda0548c109d